### PR TITLE
Some bugfixes

### DIFF
--- a/lib/deb.js
+++ b/lib/deb.js
@@ -28,7 +28,7 @@ Deb.prototype.pack = function (definition, files, callback) {
     packFiles.bind(this, files, definition),
     buildControlFile.bind(this, definition),
     function buildDebBinFile(done) {
-      fs.writeFile('./debian-binary', '2.0\n', done);
+      fs.writeFile('./' + definition.tmpPath + 'debian-binary', '2.0\n', done);
     },
     function buildPackage(done) {
       var pkgName = './' + self.controlFile.Package + '_' + self.controlFile.Version +
@@ -39,18 +39,18 @@ Deb.prototype.pack = function (definition, files, callback) {
       grunt.log.writeln('creating %s package', pkgPath);
       var writer = new ar.ArWriter(pkgPath, {variant: 'gnu'});
       writer.writeEntries([
-        './debian-binary',
-        './control.tar.gz',
-        './data.tar.gz'
+        './' + definition.tmpPath + 'debian-binary',
+        './' + definition.tmpPath + 'control.tar.gz',
+        './' + definition.tmpPath + 'data.tar.gz'
       ], function (err) {
         if (err)
           grunt.log.error('failed to write .deb file');
 
         // remove temp files
         async.parallel([
-          //fs.unlink.bind(fs, './control.tar.gz'),
-          //fs.unlink.bind(fs, './data.tar.gz'),
-          fs.unlink.bind(fs, './debian-binary'),
+          fs.unlink.bind(fs, './' + definition.tmpPath + 'control.tar.gz'),
+          fs.unlink.bind(fs, './' + definition.tmpPath + 'data.tar.gz'),
+          fs.unlink.bind(fs, './' + definition.tmpPath + 'debian-binary')
         ], done);
       });
     }

--- a/lib/deb.js
+++ b/lib/deb.js
@@ -63,16 +63,20 @@ Deb.prototype.pack = function (definition, files, callback) {
 function buildControlFile(definition, callback) {
   var self = this;
 
+  var rev = definition.info.rev ?
+      typeof definition.info.rev === 'function' ? definition.info.rev() : definition.info.rev : '1';
+
    self.controlFile = {
     Package: definition.package.name,
-    Version: definition.package.version + '-' + (definition.info.rev || '1'),
-    'Installed-Size': self.pkgSize,
+    Version: definition.package.version + '-' + rev,
+    'Installed-Size': Math.round(self.pkgSize / 1024),
     Section: 'misc',
     Priority: 'optional',
     Architecture: definition.info.arch || 'all',
     Depends: '',
     Maintainer: (definition.package.author ? (definition.package.author.name + ' ' + definition.package.author.email) : ''),
-    Description: definition.package.description
+    Description: definition.package.description,
+    Homepage: definition.package.homepage
   };
 
   // create the control file

--- a/lib/deb.js
+++ b/lib/deb.js
@@ -74,7 +74,7 @@ function buildControlFile(definition, callback) {
     Priority: 'optional',
     Architecture: definition.info.arch || 'all',
     Depends: '',
-    Maintainer: (definition.package.author ? (definition.package.author.name + ' <' + definition.package.author.email) : '>'),
+    Maintainer: (definition.package.author ? (definition.package.author.name + ' <' + definition.package.author.email) + '>' : ''),
     Description: definition.package.description,
     Homepage: definition.package.homepage
   };

--- a/lib/deb.js
+++ b/lib/deb.js
@@ -161,7 +161,8 @@ function packFiles(files, definition, callback) {
             function writeFileToTarball(data, wtf2Done) {
               self.data.entry({
                 name: '.' + crtFile.dest,
-                size: stats.size
+                size: stats.size,
+                mode: stats.mode
               }, data, function (err) {
                 wtf2Done(err, data);
               });

--- a/lib/deb.js
+++ b/lib/deb.js
@@ -74,7 +74,7 @@ function buildControlFile(definition, callback) {
     Priority: 'optional',
     Architecture: definition.info.arch || 'all',
     Depends: '',
-    Maintainer: (definition.package.author ? (definition.package.author.name + ' ' + definition.package.author.email) : ''),
+    Maintainer: (definition.package.author ? (definition.package.author.name + ' <' + definition.package.author.email) : '>'),
     Description: definition.package.description,
     Homepage: definition.package.homepage
   };

--- a/lib/deb.js
+++ b/lib/deb.js
@@ -25,7 +25,7 @@ Deb.prototype.pack = function (definition, files, callback) {
   var self = this;
 
   async.series([
-    packFiles.bind(this, files),
+    packFiles.bind(this, files, definition),
     buildControlFile.bind(this, definition),
     function buildDebBinFile(done) {
       fs.writeFile('./debian-binary', '2.0\n', done);
@@ -131,7 +131,7 @@ function buildControlFile(definition, callback) {
 
     self.control.finalize();
 
-    var file = fs.createWriteStream(path.resolve('./' + 'control.tar.gz'));
+    var file = fs.createWriteStream(path.resolve('./' + definition.tmpPath + 'control.tar.gz'));
     file.on('finish', callback);
 
     var compress = zlib.createGzip();
@@ -145,7 +145,7 @@ function buildControlFile(definition, callback) {
  *
  * @param files - an object with the following format {'path/to/source/dir': 'path/to/target/dir'} (e.g. {'../../src/lib': '/srv/productName/lib'})
  */
-function packFiles(files, callback) {
+function packFiles(files, definition, callback) {
   var self = this;
 
   async.eachSeries(files, function (crtFile, done) {
@@ -188,7 +188,7 @@ function packFiles(files, callback) {
     } else {
       grunt.log.writeln('successfully added files to .deb package');
 
-      var file = fs.createWriteStream(path.resolve('./' + 'data.tar.gz'));
+      var file = fs.createWriteStream(path.resolve('./' + definition.tmpPath + 'data.tar.gz'));
       file.on('finish', callback);
 
       var compress = zlib.createGzip();

--- a/lib/deb.js
+++ b/lib/deb.js
@@ -115,7 +115,8 @@ function buildControlFile(definition, callback) {
             grunt.log.writeln('adding script ', scriptName);
             self.control.entry({
               name: './' + scriptName,
-              size: stats.size
+              size: stats.size,
+              mode: stats.mode
             }, data, wtfDone);
           }
         ], doneScript);


### PR DESCRIPTION
Hello! Thanks for your work. :+1: 
Just used your package and it works great on mac instead of dpkg from brew. Here are some bug fixes and additions:
- added `tmpPath` option to choose temp files location
- fixed `Installed-Size`: it must be in kb, not bytes
- fixed `Maintainer`: it must be in format `name <email>`
- added `Homepage`
- added mode for files added to tar: permissions should be preserved
- added a possibility to specify rev as a function
- fixed temp files deletion (now only `debian-binary` is deleted)
